### PR TITLE
Script for adding secrets to jore4 repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test_users.json

--- a/README.md
+++ b/README.md
@@ -103,5 +103,9 @@ steps:
 ### add_secrets.py
 
 Adds robot users hsl-id e-mail and password to all jore4 repositories.
-Uses file named `test_users.json` as input for user details. This file should be created by changing placeholder values in `tests_users_template.json` to correct passwords and e-mails.
+Uses file named `test_users.json` as input for user details. This file should be created by changing placeholder values in `tests_users_template.json` to correct passwords and e-mails, these can be found from the hsl-jore4-common key-vault as secrets.
 After the script is run the secrets can be found by going to repositorys `Settings` page in github and then selecting `Secrets` tab. There should be now secrets named `ROBOT_HSLID_EMAIL` and `ROBOT_HSLID_PASSWORD` and they should show that they have been updated when you ran the script.
+
+Example usage:
+`python3 add_secrets.py`
+Running the script requires that you have python and GitHub CLI installed and access to HSLdevcom organization in GitHub. Instructions for installing GitHub CLI can be found here: https://github.com/cli/cli#installation

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Tools which are commonly used by other JORE4 projects
 - [Github Actions](#github-actions)
   - [extract-metadata](#extract-metadata)
   - [healthcheck](#healthcheck)
+- [Github scripts](#github-scripts)
+  - [add_secrets.py](#add_secretspy)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -95,3 +97,11 @@ steps:
   with:
     command: "curl --fail http://localhost:3200/actuator/health --output /dev/null --silent"
 ```
+
+## Github scripts
+
+### add_secrets.py
+
+Adds robot users hsl-id e-mail and password to all jore4 repositories.
+Uses file named `test_users.json` as input for user details. This file should be created by changing placeholder values in `tests_users_template.json` to correct passwords and e-mails.
+After the script is run the secrets can be found by going to repositorys `Settings` page in github and then selecting `Secrets` tab. There should be now secrets named `ROBOT_HSLID_EMAIL` and `ROBOT_HSLID_PASSWORD` and they should show that they have been updated when you ran the script.

--- a/github-scripts/add_secrets.py
+++ b/github-scripts/add_secrets.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import json
+
+def get_list_of_jore4_repositories():
+    response = subprocess.check_output("gh repo list HSLdevcom --topic jore4  --json nameWithOwner", shell=True)
+    repositories_as_json = json.loads(response)
+    repositories = []
+    for repository in repositories_as_json:
+      repositories.append(repository['nameWithOwner'])
+    return repositories
+
+def set_secret_for_repositories(list_of_repositories, secret_json):
+    user_email = secret_json['email']
+    user_password = secret_json['password']
+    for repository in list_of_repositories:
+      subprocess.check_output("gh secret set ROBOT_HSLID_EMAIL  -b\"{}\" --repo {}".format(user_email, repository), shell=True)
+      subprocess.check_output("gh secret set ROBOT_HSLID_PASSWORD -b\"{}\" --repo {}".format(user_password, repository), shell=True)
+      print(repository)
+
+repositories = get_list_of_jore4_repositories()
+secret_file = open('test_users.json',)
+secret_json = json.load(secret_file)
+set_secret_for_repositories(repositories, secret_json)

--- a/github-scripts/test_users_template.json
+++ b/github-scripts/test_users_template.json
@@ -1,0 +1,4 @@
+{
+  "email": "email@foruser.com",
+  "password": "password"
+}


### PR DESCRIPTION
add_secrets.py sets e-mail and password for our robot user as secrets to all jore4 repositories, so that they can be used in RF tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-tools/3)
<!-- Reviewable:end -->
