### PR TITLE
Add bundle_repo parameter to setup-e2e-environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.custom.
 # more info on docker-compose up command: https://docs.docker.com/engine/reference/commandline/compose_up/
 ```
 
+To overwrite some values in the generic docker-compose config, you could use
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+
+To use your local repository version of the docker image instead of the e2e version, you could use
+[docker-compose local build](https://docs.docker.com/compose/compose-file/compose-file-v3/#build)
+
+To run your service locally e.g. in Maven and then point services within the docker-compose network
+to use this natively running service, you could use
+[host.docker.internal](https://docs.docker.com/desktop/windows/networking/#per-container-ip-addressing-is-not-possible).
+For this, the `extra_hosts` parameter is already set for every service within the docker-compose
+package.
+
 ## Github Actions
 
 ### extract-metadata

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ To see how docker-compose bundle is created and used, refer to [wiki](https://gi
 
 Parameters:
 - bundle_version: Version of the docker-compose bundle to use (= github release version)
+- bundle_repo: The repository from whose releases the docker-compose bundle is to be downloaded
 - custom_docker_compose: Path for an additional docker-compose file to be used when starting up the environment.
 - ui_version, hasura_version, ... (*_version): Specific the docker image tag of the microservice to be used. For all options, see `/github-actions/setup-e2e-environment/action.yml`
 

--- a/github-actions/setup-e2e-environment/action.yml
+++ b/github-actions/setup-e2e-environment/action.yml
@@ -8,6 +8,10 @@ inputs:
       Version of the docker-compose bundle to use (= github release version)
     required: false
     default: "e2e-docker-compose"
+  bundle_repo:
+    description: Repository to retrieve the bundle from
+    required: false
+    default: "HSLdevcom/jore4-tools"
   ui_version:
     description:
       Version of ui to use (docker image tag). Set to "" if using the default


### PR DESCRIPTION
We're placing the temporary docker bundles to the jore4-flux repo and the final bundles to the jore4-tools repo. We need this parameter to be able to choose between them

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/8)
<!-- Reviewable:end -->
