### PR TITLE
Modify read-secrets script to allow keeping original env values

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ RUN curl -o /tmp/read-secrets.sh "https://raw.githubusercontent.com/HSLdevcom/jo
 CMD /bin/bash -c "source /tmp/read-secrets.sh && java -jar /.../xxx.jar"
 ```
 
+If the SKIP_SET_VARIABLE_SECRET_OVERRIDE environment variable is set, pre-exisiting values will not be overriden by secrets.
+
 ### download-docker-bundle.sh
 
 Downloads and extract the latest version of the docker bundle. It uses the `gh` github command line tool to retrieve the bundle from the releases.

--- a/docker/read-secrets.sh
+++ b/docker/read-secrets.sh
@@ -23,6 +23,8 @@ set -eu
 # FOO1=bar1
 # FOO2_BLABLA=bar2
 # FOO3_LOL=bar3.lolo
+#
+# If the $SKIP_SET_VARIABLE_SECRET_OVERRIDE environment variable is set, pre-exisiting values will not be overriden by secrets.
 
 # read docker secrets into environment variables
 SECRET_STORE_BASE_PATH="${SECRET_STORE_BASE_PATH:-/run/secrets}"
@@ -30,7 +32,11 @@ for SECRET_FILENAME in $(ls "$SECRET_STORE_BASE_PATH");
 do
     # replace non-alphanumeric characters with _ and convert to uppercase
     VAR_NAME=$(echo $SECRET_FILENAME | sed -E 's/[^a-zA-Z0-9]+/_/g' | tr a-z A-Z)
-    VAR_VALUE=$(cat "$SECRET_STORE_BASE_PATH/$SECRET_FILENAME")
-    export "$VAR_NAME"="$VAR_VALUE"
-    echo "Found secret '$SECRET_FILENAME', exported it as '$VAR_NAME' environment variable."
+    if [ ! -z "$SKIP_SET_VARIABLE_SECRET_OVERRIDE" ] && [ ! -z "$(printenv $VAR_NAME)" ]; then
+        echo "Secret environment value override disabled. Used existing value for '$VAR_NAME' environment variable."
+    else
+        VAR_VALUE=$(cat "$SECRET_STORE_BASE_PATH/$SECRET_FILENAME")
+        export "$VAR_NAME"="$VAR_VALUE"
+        echo "Found secret '$SECRET_FILENAME', exported it as '$VAR_NAME' environment variable."
+    fi
 done


### PR DESCRIPTION
If the SKIP_SET_VARIABLE_SECRET_OVERRIDE environment variable is set, read-secrets.sh will not overwrite existing values by secrets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/26)
<!-- Reviewable:end -->
