### PR TITLE
Remove bundle_repo input parameter from run-ci action

### DIFF
--- a/github-actions/run-ci/action.yml
+++ b/github-actions/run-ci/action.yml
@@ -1,10 +1,6 @@
 name: "Run CI workflow"
 description: "Setup the e2e environment and run cypress tests in it"
 inputs:
-  bundle_repo:
-    description: Repository to retrieve the bundle from
-    required: false
-    default: "HSLdevcom/jore4-tools"
   ui_version:
     description:
       Version of ui to use (docker image tag). Set to "" if using the default
@@ -120,7 +116,6 @@ runs:
       with:
         ui_version: "${{ inputs.ui_version }}"
         cypress_version: "${{ inputs.cypress_version }}"
-        bundle_repo: "${{ inputs.bundle_repo }}"
         hasura_version: "${{ inputs.hasura_version }}"
         auth_version: "${{ inputs.auth_version }}"
         mbtiles_version: "${{ inputs.mbtiles_version }}"


### PR DESCRIPTION
bundle_repo was already removed from the setup-e2e-environment action in commit c87bc14a0f145f19ea9b1b0462f15a39232aa42f as the input parameter was not used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/37)
<!-- Reviewable:end -->
