### PR TITLE
Add V3 of run-cypress-tests action & use it in run-ci Action

### DIFF
--- a/github-actions/run-ci/action.yml
+++ b/github-actions/run-ci/action.yml
@@ -139,6 +139,6 @@ runs:
     - name: Run e2e tests
       env:
         CYPRESS_TESTS_KEPT_IN_MEMORY: "${{ inputs.cypress_tests_kept_in_memory }}"
-      uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1
+      uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v3
       with:
         test-tags: "${{ inputs.test-tags }}"

--- a/github-actions/run-cypress-tests/action.yml
+++ b/github-actions/run-cypress-tests/action.yml
@@ -10,13 +10,8 @@ inputs:
       it to ''.
     required: false
     default: "@smoke"
-  threads:
-    description:
-      Amount of parallel executors. Supported values are 1-3.
-    required: false
-    default: "1"
   video:
-    description: 
+    description:
       Turn video on or off. Supported values are 'true' and 'false'.
     required: false
     default: 'false'
@@ -25,19 +20,11 @@ runs:
   using: "composite"
   steps:
     - name: Run the tests
-      if: inputs.video == 'false'
       run: |
-        docker exec cypress \
-          bash -c "yarn ws:db build && yarn ws:e2e cypress-parallel --script cy:run --threads ${{ inputs.threads }} \
-          --verbose --reporterModulePath '../node_modules/cypress-multi-reporters' --specsDir 'e2e/*.cy.ts' --weightsJson './parallel-weights.json'"
-      shell: bash
-
-    - name: Run the tests and record video
-      if: inputs.video == 'true'
-      run: |
-        docker exec cypress \
-          bash -c "yarn ws:db build && yarn ws:e2e cypress-parallel --script cy:run:video --threads ${{ inputs.threads }} \
-          --verbose --reporterModulePath '../node_modules/cypress-multi-reporters' --specsDir 'e2e/*.cy.ts' --weightsJson './parallel-weights.json'"
+        docker exec \
+          -e TEST_TAGS="${{ inputs.test-tags }}" \
+          -e TEST_VIDEO="${{ inputs.video }}" \
+          cypress /e2e/cypress/run_cypress_in_4K_xvfb.sh
       shell: bash
 
     - name: Retrieve test reports from container
@@ -53,8 +40,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: cypress-docker-reports
-        path: |
-          ${{ github.workspace }}/test-reports
+        path: ${{ github.workspace }}/test-reports
 
     - name: Fail the job
       # should fail the job if the tests fail


### PR DESCRIPTION
* Actual run logic contained in a shell script to simplify the action and make future changes easier. Script is in UI repo and is packed into the E2E Docker image.
* Dropped parallelization bits from the unreleased V2. Parallelization requires completely separated databases and needs to happen at a higher level.
* Starts a custom Xvfb server with 4K resolution for high res screenshots.
* Instructs Cypress to start the headless browser in 4K mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/38)
<!-- Reviewable:end -->
