### PR TITLE
Do not require sqlcmd to be installed on the GHA runner when setting …

### DIFF
--- a/github-actions/setup-e2e-environment/action.yml
+++ b/github-actions/setup-e2e-environment/action.yml
@@ -172,9 +172,21 @@ runs:
       env:
         SA_PASSWORD: "P@ssw0rd"
       with:
+        # The IP address of MS SQL Docker container is retrieved using docker inspect because the container
+        # does not have a predefined or predictable hostname. A predefined hostname could be added in docker
+        # compose bundle.
         command:
-          'sqlcmd -S 127.0.0.1 -U sa -P "$SA_PASSWORD" -d master -Q "SELECT
-          ''OK'';"'
+          docker run
+            --rm
+            --network docker_jore4 \
+            $(docker inspect mssqltestdb | jq -r '.[0].Config.Image')
+            /opt/mssql-tools18/bin/sqlcmd
+            -C
+            -S $(docker inspect mssqltestdb | jq -r '.[0].NetworkSettings'.Networks.docker_jore4.IPAddress)
+            -U sa
+            -P "$SA_PASSWORD"
+            -d master
+            -Q "SELECT ''OK'';"
         # it takes a while for the database to start
         retries: 50
 


### PR DESCRIPTION
…up e2e environment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/44)
<!-- Reviewable:end -->
