### PR TITLE
Add Git SHA to built Docker images as label

### DIFF
--- a/.github/workflows/shared-build-and-publish-docker-image.yml
+++ b/.github/workflows/shared-build-and-publish-docker-image.yml
@@ -102,6 +102,8 @@ jobs:
           tags: |
             ${{ steps.variables.outputs.docker_image }}
             ${{ github.ref_name == 'main' && steps.variables.outputs.docker_image_latest || '' }}
+          labels: |
+            git_sha=${{ github.sha }}
           cache-from: type=registry,ref=${{ steps.variables.outputs.docker_image_cache }}
           cache-to: ${{ github.ref_name == 'main' && format('type=registry,ref={0},mode=max', steps.variables.outputs.docker_image_cache) || '' }}
           push: true


### PR DESCRIPTION
This allows an easy programmatic way to find out the commit from which a Docker image was built.

This change needs to be deployed before some other GHA actions are updated so that the cypress image contains label containing source Git commit SHA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/46)
<!-- Reviewable:end -->
