### PR TITLE
Use latest node version for shared check renovatebot config

### DIFF
--- a/.github/workflows/check-renovatebot-config.yml
+++ b/.github/workflows/check-renovatebot-config.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   validate:
-    uses: HSLdevcom/jore4-tools/.github/workflows/shared-check-renovatebot-config.yml@shared-check-renovatebot-config-v1
+    uses: HSLdevcom/jore4-tools/.github/workflows/shared-check-renovatebot-config.yml@shared-check-renovatebot-config-v2
     with:
       config_file_path: renovatebot/jore4-default-preset.json5

--- a/.github/workflows/shared-check-renovatebot-config.yml
+++ b/.github/workflows/shared-check-renovatebot-config.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           submodules: ${{ inputs.checkout_submodules }}
 
+      - name: Setup latest lts Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
       - name: Validate config
         uses: suzuki-shunsuke/github-action-renovate-config-validator@c22827f47f4f4a5364bdba19e1fe36907ef1318e # v1.1.1
         with:


### PR DESCRIPTION
Set up the latest LTS node version so that the latest version of renovatebot can be used.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/60)
<!-- Reviewable:end -->
