### PR TITLE
Allow Blue Oak license

### DIFF
--- a/.github/dependency-scan-config.yaml
+++ b/.github/dependency-scan-config.yaml
@@ -70,6 +70,7 @@ allow-licenses:
   - APSL-2.0
   - Artistic-1.0-Perl
   - Artistic-2.0
+  - BlueOak-1.0.0
   - BSL-1.0
   - CATOSL-1.1
   - CPAL-1.0


### PR DESCRIPTION
Isaac Z. Schlueter, the author of such ever prevalent node packages as 'glob', 'rimraf' and 'lru-cache' has decided to switch from ISC license to using the Blue Oak license instead. It seems to be no particularly different from other OSS licenses, and ought to be compatible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/75)
<!-- Reviewable:end -->
