### PR TITLE
Seed tram infralinks into e2e-setup

### DIFF
--- a/.github/workflows/shared-run-e2e.yml
+++ b/.github/workflows/shared-run-e2e.yml
@@ -179,7 +179,7 @@ jobs:
           start_jore3_importer: "${{ inputs.start_jore3_importer }}"
 
       - name: Seed infrastructure links
-        uses: HSLdevcom/jore4-tools/github-actions/seed-infrastructure-links@seed-infrastructure-links-v4
+        uses: HSLdevcom/jore4-tools/github-actions/seed-infrastructure-links@seed-infrastructure-links-v5
 
       - name: Seed municipalities and fare zones
         uses: HSLdevcom/jore4-tools/github-actions/seed-municipalities-and-fare-zones@seed-municipalities-and-fare-zones-v2


### PR DESCRIPTION
 - Now that hasura handles the infralink coupling correctly, we can seed the tram infralinks into test data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-tools/77)
<!-- Reviewable:end -->
